### PR TITLE
TLS - Added Parachute and Emergency Eject actions

### DIFF
--- a/client/init.sqf
+++ b/client/init.sqf
@@ -11,5 +11,3 @@ player addEventHandler ["Killed", { _this spawn onKilled }];
 
 // Emergency eject and magic parachute
 
-player addAction ["Emergency eject",  { moveout player; }, [], -10, false, true, "", "(vehicle player) isKindOf 'Helicopter'"];  
-player addAction ["Magic Parachute",  { _mp = createVehicle ["Steerable_Parachute_F", getPosATL player, [], 0, "CAN_COLLIDE"] ; _mp setDir getDir player; player moveInDriver _mp; _mp setVelocity [0,0,0]; }, [], 20, false, true, "", "vehicle player == player && (getPos player) select 2 > 2"];

--- a/init.sqf
+++ b/init.sqf
@@ -11,7 +11,6 @@ enableSaving [false, false];
 [] execVM "scripts\briefing.sqf";
 
 // Revive system
-
 [] spawn SRS_fnc_init;
 
 // View distance config

--- a/onPlayerRespawn.sqf
+++ b/onPlayerRespawn.sqf
@@ -1,8 +1,3 @@
-private ["_player"];
-{
-	_player = _this select 0;
-	
-	_player addAction ["Emergency eject",  { moveout player; }, [], -10, false, true, "", "(vehicle player) isKindOf 'Helicopter'"];  
-	_player addAction ["Magic Parachute",  { _mp = createVehicle ["Steerable_Parachute_F", getPosATL player, [], 0, "CAN_COLLIDE"] ; _mp setDir getDir player; player moveInDriver _mp; _mp setVelocity [0,0,0]; }, [], 20, false, true, "", "vehicle player == player && (getPos player) select 2 > 2"];
-
-};
+//Add player actions
+	playerEE = player addAction ["<t color='#FF0000'>Emergency Eject</t>",  { moveout player; }, [], -10, false, true, "", "(vehicle player) isKindOf 'Helicopter'"];  
+	playerMagicPara = player addAction ["<t color='#0000FF'>Open magic parachute</t>",  { _mp = createVehicle ["Steerable_Parachute_F", getPosATL player, [], 0, "CAN_COLLIDE"] ; _mp setDir getDir player; player moveInDriver _mp; _mp setVelocity [0,0,0]; }, [], 20, false, true, "", "vehicle player == player && (getPos player) select 2 > 2"];


### PR DESCRIPTION
Added addAction code to 'onPlayerRespawn.sqf' for both Emergency Eject
(from choppers) and Magic Parachute.

Removed similar code from 'client\init.sqf' as this was non-functioning.
